### PR TITLE
Handle more corrupt streams by detecting no progress

### DIFF
--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -1,0 +1,60 @@
+extern crate xz2;
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+use xz2::read;
+use xz2::write;
+
+#[test]
+fn standard_files() {
+    for file in Path::new("lzma-sys/xz-5.2.3/tests/files").read_dir().unwrap() {
+        let file = file.unwrap();
+        if file.path().extension().and_then(|s| s.to_str()) != Some("xz") {
+            continue
+        }
+
+        let filename = file.file_name().into_string().unwrap();
+
+        // This appears to be implementation-defined how it's handled
+        if filename.contains("unsupported-check") {
+            continue
+        }
+
+        // These seem to be concatenated streams which we don't support yet
+        if filename.contains("good-0pad-empty") {
+            continue
+        }
+        if filename.contains("good-0catpad-empty") {
+            continue
+        }
+        if filename.contains("good-0cat-empty") {
+            continue
+        }
+
+        println!("testing {:?}", file.path());
+        let mut contents = Vec::new();
+        File::open(&file.path()).unwrap().read_to_end(&mut contents).unwrap();
+        if filename.starts_with("bad") || filename.starts_with("unsupported") {
+            test_bad(&contents);
+        } else {
+            test_good(&contents);
+        }
+    }
+}
+
+fn test_good(data: &[u8]) {
+    let mut ret = Vec::new();
+    read::XzDecoder::new(data).read_to_end(&mut ret).unwrap();
+    let mut w = write::XzDecoder::new(ret);
+    w.write_all(data).unwrap();
+    w.finish().unwrap();
+}
+
+fn test_bad(data: &[u8]) {
+    let mut ret = Vec::new();
+    assert!(read::XzDecoder::new(data).read_to_end(&mut ret).is_err());
+    let mut w = write::XzDecoder::new(ret);
+    assert!(w.write_all(data).is_err() || w.finish().is_err());
+}


### PR DESCRIPTION
Also try parsing/decoding all of the xz files in the xz test suite to try to
catch a few regressions.

Closes #9