### PR TITLE
Fixes for building on Solaris

### DIFF
--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -147,7 +147,7 @@ fn main() {
 fn make(host: &String) -> Command {
     let mut cmd = if host.contains("bitrig") || host.contains("dragonfly") ||
         host.contains("freebsd") || host.contains("netbsd") ||
-        host.contains("openbsd") {
+        host.contains("openbsd") || host.contains("solaris") {
 
         Command::new("gmake")
     } else {

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -137,7 +137,10 @@ fn main() {
                     .arg(&format!("-j{}", env::var("NUM_JOBS").unwrap()))
                     .current_dir(&dst.join("build")));
         // Unset DESTDIR or liblzma.a ends up in it and cargo can't find it
+        // MAKEFLAGS may also contain DESTDIR (from 'make install DESTDIR=...')
+        // so we should get rid of that as well
         env::remove_var("DESTDIR");
+        env::remove_var("MAKEFLAGS");
         run(make(&host)
                     .arg("install")
                     .current_dir(&dst.join("build/src/liblzma")));


### PR DESCRIPTION
If `$PATH` isn't set to put `/usr/gnu/bin` before `/usr/bin`, `/usr/bin/make` will complain about the `-j` option being unsupported.

If the component is built from within a `make`-based build system that sets `DESTDIR` on `make`'s commandline (rather than as an environment variable), then the `DESTDIR` setting ends up in the `MAKEFLAGS` environment variable, and the submake will install into the bogus DESTDIR, anyway. If we remove `MAKEFLAGS` from the environment (which makes some sense, anyway), then this problem goes away.