### PR TITLE
Support of multi-stream input.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xz2"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/read.rs
+++ b/src/read.rs
@@ -111,10 +111,19 @@ impl<R: AsyncWrite + Read> AsyncWrite for XzEncoder<R> {
 
 impl<R: Read> XzDecoder<R> {
     /// Create a new decompression stream, which will read compressed
-    /// data from the given input stream and decompress it.
+    /// data from the given input stream and decompress it. Input
+    /// can contain several concatenated xz streams.
     pub fn new(r: R) -> XzDecoder<R> {
         XzDecoder {
             inner: bufread::XzDecoder::new(BufReader::new(r)),
+        }
+    }
+    /// Create a new decompression stream, which will read compressed
+    /// data from the given input stream and decompress it. Flags
+    /// such as `CONCATENATED` can be provided to configure the decompression.
+    pub fn new_with_opt(r: R, flags: u32) -> XzDecoder<R> {
+        XzDecoder {
+            inner: bufread::XzDecoder::new_with_opt(BufReader::new(r), flags),
         }
     }
 
@@ -242,7 +251,7 @@ mod tests {
             result.extend(v.iter().map(|x| *x));
         }
 
-        let mut d = XzDecoder::new(&result[..]);
+        let mut d = XzDecoder::new_with_opt(&result[..], 0);
         let mut data = Vec::with_capacity(m.len());
         unsafe { data.set_len(m.len()); }
         assert!(d.read(&mut data).unwrap() == m.len());

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,6 +2,7 @@
 
 use std::io::prelude::*;
 use std::io;
+use lzma_sys;
 
 #[cfg(feature = "tokio")]
 use futures::Poll;
@@ -176,7 +177,7 @@ impl<W: Write> XzDecoder<W> {
     /// Creates a new decoding stream which will decode all input written to it
     /// into `obj`.
     pub fn new(obj: W) -> XzDecoder<W> {
-        let stream = Stream::new_stream_decoder(u64::max_value(), 0).unwrap();
+        let stream = Stream::new_stream_decoder(u64::max_value(), lzma_sys::LZMA_CONCATENATED).unwrap();
         XzDecoder::new_stream(obj, stream)
     }
 
@@ -218,7 +219,7 @@ impl<W: Write> XzDecoder<W> {
         loop {
             try!(self.dump());
             let res = try!(self.data.process_vec(&[], &mut self.buf,
-                                                 Action::Run));
+                                                 Action::Finish));
 
             // When decoding a truncated file, XZ returns LZMA_BUF_ERROR and
             // decodes no new data, which corresponds to this crate's MemNeeded

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -23,17 +23,6 @@ fn standard_files() {
             continue
         }
 
-        // These seem to be concatenated streams which we don't support yet
-        if filename.contains("good-0pad-empty") {
-            continue
-        }
-        if filename.contains("good-0catpad-empty") {
-            continue
-        }
-        if filename.contains("good-0cat-empty") {
-            continue
-        }
-
         println!("testing {:?}", file.path());
         let mut contents = Vec::new();
         File::open(&file.path()).unwrap().read_to_end(&mut contents).unwrap();


### PR DESCRIPTION
Related to bug #25. With this modification, stream decoder in created by default with the option `Concatenate` which makes the decoder process all the concatenated xz streams of the input. With this modification, unit tests now pass for the 3 sample files having several xz streams.

It will break existing programs that expect exactly one xz stream to be consumed because:
* more data than expected will be processed
* if one valid xz stream is followed by non-xz data, then the decoder will return an error.
I think that library users may prefer by default to consume all the data (whether it's made of one or several xz streams). I'm divided on breaking the backward compatibility (my pick) or not. It could be mentioned in the documentation, but not everybody will not notice. Or it could be possible to keep the existing builder methods and introduce new ones using `Concatenate` option.

Now, when we reached the end of the input data, we need to call the decoder with `Action::Finish` instead of `Action::Run` (done).

For the unit test `self_terminating`, it required creating the decoder without the `Concatenate` option. In this test scenario, some random garbage is appended after the (valid) input compressed data, which was fine without the option `Concatenate` because the decoder would stop at the end of the first xz stream (and ignore the garbage). With `Concatenate`, the decoder will continue after the first xz stream, but it will find invalid xz data and fail. I can imagine that a decoder without `Concatenate` can be useful when one xz stream in embedded inside a larger non-xz stream of data.

I'm not a seasoned Rust developer so I'm not sure to have modified the code in a good manner. Also, now I think that version should become `0.2.0` because new functionalities are offered.

**Edit**: reformulated the description about backward compatibility