### PR TITLE
More specific dependency versions

### DIFF
--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -17,8 +17,8 @@ High level Rust bindings are available in the `xz2` crate.
 categories = ["external-ffi-bindings"]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.43"
 
 [build-dependencies]
-cc = "1.0"
-pkg-config = "0.3"
+cc = "1.0.24"
+pkg-config = "0.3.14"


### PR DESCRIPTION
The crate currently doesn't build with `cargo build -Z minimal-versions` due to allowing a bitrotten pkg-config version.