### PR TITLE
Migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
-rand = "0.5"
-quickcheck = "0.7"
+rand = "0.6"
+quickcheck = "0.8"
 tokio-core = "0.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ Rust bindings to liblzma providing Read/Write streams as well as low-level
 in-memory encoding/decoding.
 """
 categories = ["compression", "api-bindings"]
+edition = "2018"
 
 [workspace]
 members = ["systest"]

--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -15,6 +15,7 @@ encoding/decoding.
 High level Rust bindings are available in the `xz2` crate.
 """
 categories = ["external-ffi-bindings"]
+edition = "2018"
 
 [dependencies]
 libc = "0.2.43"

--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -18,8 +18,8 @@ categories = ["external-ffi-bindings"]
 edition = "2018"
 
 [dependencies]
-libc = "0.2.43"
+libc = "0.2"
 
 [build-dependencies]
-cc = "1.0.24"
-pkg-config = "0.3.14"
+cc = "1.0"
+pkg-config = "0.3"

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -1,6 +1,3 @@
-extern crate cc;
-extern crate pkg_config;
-
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/lzma-sys/src/lib.rs
+++ b/lzma-sys/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(bad_style)]
 #![doc(html_root_url = "https://docs.rs/lzma-sys/0.1")]
 
-extern crate libc;
-
 use libc::{c_char, c_uchar, c_void, size_t};
 use std::u64;
 

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -9,7 +9,7 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use stream::{Action, Check, Status, Stream};
+use crate::stream::{Action, Check, Status, Stream};
 
 /// An xz encoder, or compressor.
 ///
@@ -253,7 +253,7 @@ impl<R: AsyncWrite> AsyncWrite for XzDecoder<R> {
 
 #[cfg(test)]
 mod tests {
-    use bufread::{XzDecoder, XzEncoder};
+    use crate::bufread::{XzDecoder, XzEncoder};
     use std::io::Read;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,18 +46,6 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/xz2/0.1")]
 
-extern crate lzma_sys;
-
-#[cfg(test)]
-extern crate quickcheck;
-#[cfg(test)]
-extern crate rand;
-#[cfg(feature = "tokio")]
-#[macro_use]
-extern crate tokio_io;
-#[cfg(feature = "tokio")]
-extern crate futures;
-
 pub mod stream;
 
 pub mod bufread;

--- a/src/read.rs
+++ b/src/read.rs
@@ -201,9 +201,10 @@ impl<R: AsyncWrite + Read> AsyncWrite for XzDecoder<R> {
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, Rng};
     use crate::read::{XzDecoder, XzEncoder};
+    use rand::{thread_rng, Rng};
     use std::io::prelude::*;
+    use std::iter;
 
     #[test]
     fn smoke() {
@@ -245,7 +246,10 @@ mod tests {
         let mut result = Vec::new();
         c.read_to_end(&mut result).unwrap();
 
-        let v = thread_rng().gen_iter::<u8>().take(1024).collect::<Vec<_>>();
+        let mut rng = thread_rng();
+        let v = iter::repeat_with(|| rng.gen::<u8>())
+            .take(1024)
+            .collect::<Vec<_>>();
         for _ in 0..200 {
             result.extend(v.iter().map(|x| *x));
         }

--- a/src/read.rs
+++ b/src/read.rs
@@ -8,8 +8,8 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use bufread;
-use stream::Stream;
+use crate::bufread;
+use crate::stream::Stream;
 
 /// A compression stream which wraps an uncompressed stream of data. Compressed
 /// data will be read from the stream.
@@ -202,7 +202,7 @@ impl<R: AsyncWrite + Read> AsyncWrite for XzDecoder<R> {
 #[cfg(test)]
 mod tests {
     use rand::{thread_rng, Rng};
-    use read::{XzDecoder, XzEncoder};
+    use crate::read::{XzDecoder, XzEncoder};
     use std::io::prelude::*;
 
     #[test]

--- a/src/write.rs
+++ b/src/write.rs
@@ -9,7 +9,7 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use stream::{Action, Check, Status, Stream};
+use crate::stream::{Action, Check, Status, Stream};
 
 /// A compression stream which will have uncompressed data written to it and
 /// will write compressed data to an output stream.

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -3,6 +3,7 @@ name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 lzma-sys = { path = "../lzma-sys" }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,5 +1,3 @@
-extern crate ctest;
-
 use std::env;
 
 fn main() {

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,8 +1,5 @@
 #![allow(bad_style)]
 
-extern crate libc;
-extern crate lzma_sys;
-
 use libc::*;
 use lzma_sys::*;
 

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,6 +1,4 @@
 #![allow(bad_style)]
-
-use libc::*;
 use lzma_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));

--- a/tests/drop-incomplete.rs
+++ b/tests/drop-incomplete.rs
@@ -1,5 +1,3 @@
-extern crate xz2;
-
 use std::io::prelude::*;
 use xz2::write::XzDecoder;
 

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,11 +1,5 @@
 #![cfg(feature = "tokio")]
 
-extern crate futures;
-extern crate rand;
-extern crate tokio_core;
-extern crate tokio_io;
-extern crate xz2;
-
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpListener};
 use std::thread;

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -1,5 +1,3 @@
-extern crate xz2;
-
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;


### PR DESCRIPTION
This PR migrates the crates to Rust 2018 edition. Also it updates some dependencies.