### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -820,15 +820,11 @@ impl From<Error> for io::Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "lzma data error"
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        error::Error::description(self).fmt(f)
+        "lzma data error".fmt(f)
     }
 }
 


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes the implementation of `description` 

Related PR: https://github.com/rust-lang/rust/pull/66919