### PR TITLE
fix static build on illumos systems

### DIFF
--- a/lzma-sys/config.h
+++ b/lzma-sys/config.h
@@ -38,3 +38,8 @@
     #define _POSIX_C_SOURCE 199506L
     #define MYTHREAD_POSIX 1
 #endif
+
+#if defined(__sun)
+    #define HAVE_CLOCK_GETTIME 1
+    #define HAVE_DECL_CLOCK_MONOTONIC 1
+#endif


### PR DESCRIPTION
On illumos systems, gettimeofday() is not visible when compiling against
for the POSIX.1c-1996 standard, as requested by the definition of
_POSIX_C_SOURCE as 199506L in "lzma-sys/config.h".  This routine is only
used as a fallback when clock_gettime(CLOCK_MONOTONIC) is not available,
but it definitely is here so we can enable it.