### PR TITLE
build.rs declares output directory to cargo

### DIFF
--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -22,6 +22,8 @@ fn main() {
         return;
     }
 
+    let out_dir = env::var("OUT_DIR").unwrap();
+    println!("cargo:root={}", out_dir);
     let include_dir = env::current_dir().unwrap().join("xz-5.2/src/liblzma/api");
     println!("cargo:include={}", include_dir.display());
 


### PR DESCRIPTION
By declaring the directory where `liblzma` is built to cargo, a dependent crate can use that built library when linking native non-Rust code by an external build system. The environment variable `DEP_LZMA_ROOT` would allow access to the built `liblzma`.