### PR TITLE
Render with more cargo features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ tokio-core = "0.1.17"
 
 [features]
 tokio = ["tokio-io", "futures"]
+
+[package.metadata.docs.rs]
+features = ["tokio-io", "futures"]


### PR DESCRIPTION
It enables `tokio-io` and `futures` cargo features on docs.rs.