### PR TITLE
Made ErrorKind for std::io::Error more specific

### DIFF
--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -220,12 +220,12 @@ impl<R: BufRead> Read for XzDecoder<R> {
             let status = ret?;
             if read > 0 || eof || buf.len() == 0 {
                 if read == 0 && status != Status::StreamEnd && buf.len() > 0 {
-                    return Err(io::Error::new(io::ErrorKind::Other, "premature eof"));
+                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "premature eof"));
                 }
                 return Ok(read);
             }
             if consumed == 0 {
-                return Err(io::Error::new(io::ErrorKind::Other, "corrupt xz stream"));
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "corrupt xz stream"));
             }
         }
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -816,7 +816,18 @@ fn cvt(rc: lzma_sys::lzma_ret) -> Result<Status, Error> {
 
 impl From<Error> for io::Error {
     fn from(e: Error) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, e)
+        let kind = match e {
+            Error::Data => std::io::ErrorKind::InvalidData,
+            Error::Options => std::io::ErrorKind::InvalidInput,
+            Error::Format => std::io::ErrorKind::InvalidData,
+            Error::MemLimit => std::io::ErrorKind::Other,
+            Error::Mem => std::io::ErrorKind::Other,
+            Error::Program => std::io::ErrorKind::Other,
+            Error::NoCheck => std::io::ErrorKind::InvalidInput,
+            Error::UnsupportedCheck => std::io::ErrorKind::Other,
+        };
+
+        io::Error::new(kind, e)
     }
 }
 
@@ -824,7 +835,16 @@ impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "lzma data error".fmt(f)
+        match self {
+            Error::Data => "lzma data error",
+            Error::Options => "invalid options",
+            Error::Format => "stream/file format not recognized",
+            Error::MemLimit => "memory limit reached",
+            Error::Mem => "can't allocate memory",
+            Error::Program => "liblzma internal error",
+            Error::NoCheck => "no integrity check was available",
+            Error::UnsupportedCheck => "liblzma not built with check support"
+        }.fmt(f)
     }
 }
 


### PR DESCRIPTION
This helps with fallbacks (don't decompress, return compressed) and allows better error recovery for programs using xz2.

I'm not 100% sure if all `ErrorKind`s are appropriate as I have never worked with liblzma. Let me know if some changes need to be made.

I also added more descriptive error display strings so that crashes give more insight into why they happened.