### PR TITLE
Optionally allow trailing data in `bufread::XzDecoder`

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -345,6 +345,20 @@ mod tests {
     }
 
     #[test]
+    fn trailing_data() {
+        let mut c = XzEncoder::new(Vec::new(), 6);
+        c.write_all(b"12834").unwrap();
+        let mut compressed = c.finish().unwrap();
+        compressed.extend(b"asdf");
+        let mut d = XzDecoder::new(Vec::new());
+        assert_eq!(d.write(&compressed).unwrap(), compressed.len() - 4);
+        assert_eq!(d.write(b"asdf").unwrap(), 0);
+        assert_eq!(d.write(b"asdf").unwrap(), 0);
+        let data = d.finish().unwrap();
+        assert_eq!(&data, b"12834");
+    }
+
+    #[test]
     fn qc() {
         ::quickcheck::quickcheck(test as fn(_) -> _);
 


### PR DESCRIPTION
Some xz streams have unrelated data afterward.  In particular, Linux kernel initrd files are the concatenation of multiple cpio archives, each of which can be compressed with a different compressor.  `read::XzDecoder` and `bufread::XzDecoder` return `InvalidData` in this case, which makes it difficult to detect the EOF, unwrap the underlying stream, and continue reading with a different decompressor.  (`write::XzDecoder` returns `Ok(0)` after the end of the xz stream, which is less ambiguous.)  Multi-decoder mode doesn't address this, since that only handles the case where the following data is also an xz stream.

liblzma properly returns `StreamEnd` here; we just need to detect it. However, the xz test suite contains some tests with trailing garbage, and the `xz` command-line tool is designed to fail on those unless `--single-stream` is specified.  For compatibility, we probably can't allow trailing garbage by default, but we can provide an option.  Add an `allow_trailing_data()` toggle to `bufread::XzDecoder`, and stop accepting bytes in `read()` if we reach `StreamEnd` with that toggle enabled.

Do not add a similar option to `read::XzDecoder`, since it's only useful if the underlying stream is synced to the end of the xz stream afterward, and `read::XzDecoder` can't ensure that.

Also add an additional test verifying that `write::XzDecoder` refuses to accept additional bytes after the xz stream reaches `StreamEnd`.