### PR TITLE
Enable feature parallel for build-dep cc

### DIFF
--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 libc = "0.2.51"
 
 [build-dependencies]
-cc = "1.0.34"
+cc = { version = "1.0.34", features = ["parallel"] }
 pkg-config = "0.3.14"
 
 [features]


### PR DESCRIPTION
Before this patch, `cargo b --release --features static` takes 4.5s and after this PR it only takes 2.49s on my M1, giving almost 2x speedup.