### PR TITLE
Optimize `liblzma.a` build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,7 @@ static = ["lzma-sys/static"]
 fat-lto = ["lzma-sys/fat-lto"]
 thin-lto = ["lzma-sys/thin-lto"]
 
+thin = ["lzma-sys/thin"]
+
 [package.metadata.docs.rs]
 features = ["tokio-io", "futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,8 @@ tokio-core = "0.1.17"
 tokio = ["tokio-io", "futures"]
 static = ["lzma-sys/static"]
 
+fat-lto = ["lzma-sys/fat-lto"]
+thin-lto = ["lzma-sys/thin-lto"]
+
 [package.metadata.docs.rs]
 features = ["tokio-io", "futures"]

--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -26,3 +26,6 @@ pkg-config = "0.3.14"
 
 [features]
 static = []
+
+fat-lto = [] # Enable fat-lto, will override thin-lto if specified
+thin-lto = [] # Enable thin-lto, will fallback to fat-lto if not supported

--- a/lzma-sys/Cargo.toml
+++ b/lzma-sys/Cargo.toml
@@ -29,3 +29,5 @@ static = []
 
 fat-lto = [] # Enable fat-lto, will override thin-lto if specified
 thin-lto = [] # Enable thin-lto, will fallback to fat-lto if not supported
+
+thin = [] # Enable HAVE_SMALL to optimize for size

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -81,6 +81,16 @@ fn main() {
         .flag_if_supported("-Wl,--gc-sections")
         .flag_if_supported("-Wl,--icf=safe");
 
+    if cfg!(feature = "fat-lto") {
+        build.flag_if_supported("-flto");
+    } else if cfg!(feature = "thin-lto") {
+        if build.is_flag_supported("-flto=thin").unwrap_or(false) {
+            build.flag("-flto=thin");
+        } else {
+            build.flag_if_supported("-flto");
+        }
+    }
+
     build.compile("liblzma.a");
 }
 

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -74,6 +74,13 @@ fn main() {
         }
     }
 
+    build
+        .flag_if_supported("-ffunction-sections")
+        .flag_if_supported("-fdata-sections")
+        .flag_if_supported("-fmerge-all-constants")
+        .flag_if_supported("-Wl,--gc-sections")
+        .flag_if_supported("-Wl,--icf=safe");
+
     build.compile("liblzma.a");
 }
 

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -77,9 +77,7 @@ fn main() {
     build
         .flag_if_supported("-ffunction-sections")
         .flag_if_supported("-fdata-sections")
-        .flag_if_supported("-fmerge-all-constants")
-        .flag_if_supported("-Wl,--gc-sections")
-        .flag_if_supported("-Wl,--icf=safe");
+        .flag_if_supported("-fmerge-all-constants");
 
     if cfg!(feature = "fat-lto") {
         build.flag_if_supported("-flto");

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -91,6 +91,10 @@ fn main() {
         }
     }
 
+    if cfg!(feature = "thin") {
+        build.define("HAVE_SMALL", Some("1"));
+    }
+
     build.compile("liblzma.a");
 }
 

--- a/lzma-sys/build.rs
+++ b/lzma-sys/build.rs
@@ -93,6 +93,8 @@ fn main() {
 
     if cfg!(feature = "thin") {
         build.define("HAVE_SMALL", Some("1"));
+
+        build.opt_level_str("z");
     }
 
     build.compile("liblzma.a");

--- a/lzma-sys/config.h
+++ b/lzma-sys/config.h
@@ -39,6 +39,8 @@
     #define MYTHREAD_POSIX 1
 #endif
 
+#define NDEBUG 1
+
 #if defined(__sun)
     #define HAVE_CLOCK_GETTIME 1
     #define HAVE_DECL_CLOCK_MONOTONIC 1


### PR DESCRIPTION
 -  Reduce `liblzma.a` size by using `--gc-sections`
 -  Add new feat `fat-lto` and `thin-lto` to turn out fat and thin lto for building `liblzma.a`
 -  Add new feat `thin` to optimize for size using macro [`HAVE_SMALL`]

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

[`HAVE_SMALL`]: https://github.com/xz-mirror/xz/blob/2327a461e1afce862c22269b80d3517801103c1b/configure.ac#L332-L344