### PR TITLE
Enable CI for `stable-i686-gnu` on `windows`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,8 @@ jobs:
             rust: stable-x86_64-msvc
             static: yes
             crt_static: yes
-          # TODO: should figure out why this is failing
-          # - os: windows-latest
-          #   rust: stable-i686-gnu
+          - os: windows-latest
+            rust: stable-i686-gnu
           - os: windows-latest
             rust: stable-x86_64-gnu
     steps:


### PR DESCRIPTION
Hi @alexcrichton 

It's been a while since the test was disabled, so I ran it again in the current GitHub Actions Runner environment and report that it ran successfully.