### PR TITLE
Fix a broken link in a doc comment

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -112,7 +112,7 @@ impl<R: Read> XzDecoder<R> {
     /// Create a new decompression stream, which will read compressed
     /// data from the given input stream, and decompress one xz stream.
     /// It may also consume input data that follows the xz stream.
-    /// Use [`xz::bufread::XzDecoder`] instead to process a mix of xz and non-xz data.
+    /// Use [`bufread::XzDecoder`] instead to process a mix of xz and non-xz data.
     pub fn new(r: R) -> XzDecoder<R> {
         XzDecoder {
             inner: bufread::XzDecoder::new(BufReader::new(r)),


### PR DESCRIPTION
This small PR fixes a broken link in a doc comment from `read::XzDecoder` to `bufread::XzDecoder`.