### PR TITLE
Fix static build on FreeBSD

### DIFF
--- a/lzma-sys/config.h
+++ b/lzma-sys/config.h
@@ -39,7 +39,7 @@
     #define MYTHREAD_POSIX 1
 #endif
 
-#if defined(__sun)
+#if defined(__sun) || defined(__FreeBSD__)
     #define HAVE_CLOCK_GETTIME 1
     #define HAVE_DECL_CLOCK_MONOTONIC 1
 #endif


### PR DESCRIPTION
Similar to the previous illumos issue (#61), FreeBSD does not expose `gettimeofday` with the set value of `_POSIX_C_SOURCE`. The same fix, configuring liblzma to use `clock_gettime`, works on FreeBSD.

It might be useful to extend this patch to also match other BSD (or even System V) derivatives but I have only tested this on FreeBSD.